### PR TITLE
Controller shown in transparent-blue color bug fixed

### DIFF
--- a/driver/src/device/pose/device_pose.cpp
+++ b/driver/src/device/pose/device_pose.cpp
@@ -68,15 +68,10 @@ vr::DriverPose_t DevicePose::UpdatePose() const {
   const vr::HmdVector3d_t controller_position = MatrixToPosition(controller_pose.mDeviceToAbsoluteTracking);
   const vr::HmdQuaternion_t controller_orientation = MatrixToOrientation(controller_pose.mDeviceToAbsoluteTracking);
 
-  result.qWorldFromDriverRotation = controller_orientation;
-
-  result.vecWorldFromDriverTranslation[0] = controller_position.v[0];
-  result.vecWorldFromDriverTranslation[1] = controller_position.v[1];
-  result.vecWorldFromDriverTranslation[2] = controller_position.v[2];
-
-  result.vecPosition[0] = configuration_.offset_position.v[0];
-  result.vecPosition[1] = configuration_.offset_position.v[1];
-  result.vecPosition[2] = configuration_.offset_position.v[2];
+  auto new_position = controller_position + configuration_.offset_position * controller_orientation * configuration_.offset_orientation;
+  result.vecPosition[0] = new_position.v[0];
+  result.vecPosition[1] = new_position.v[1];
+  result.vecPosition[2] = new_position.v[2];
 
   const vr::HmdVector3_t velocity = controller_pose.vVelocity * -controller_orientation;
   result.vecVelocity[0] = velocity.v[0];
@@ -88,7 +83,7 @@ vr::DriverPose_t DevicePose::UpdatePose() const {
   result.vecAngularVelocity[1] = angular_velocity.v[1];
   result.vecAngularVelocity[2] = angular_velocity.v[2];
 
-  result.qRotation = configuration_.offset_orientation;
+  result.qRotation = controller_orientation * configuration_.offset_orientation;
 
   result.poseIsValid = true;
   result.deviceIsConnected = true;


### PR DESCRIPTION
(I'll write a description of the bug here, but let me know if you want me to open an issue)

## Issue
When we launch SteamVR and turn on the vive tracker, the hand appears for about 10 seconds before changing into a transparent-blue form, similar to what happens when you place a controller outside the boundaries.
This problem could be reproduced by using version [0.5.2](https://github.com/LucidVR/opengloves-driver/releases/tag/v0.5.2). 

Specifically, [this PR]( https://github.com/LucidVR/opengloves-driver/pull/199) is likely to be causing the issue.

## Changes
The issue was resolved by ensuring that the worldFromDriverTranslation and rotation values do not change from the beginning, rather than calculating the base position using these values and adding offsets.


https://user-images.githubusercontent.com/33923222/208230400-f0c60312-1d05-4c2e-b142-31df67f68597.mp4



