### PR TITLE
Update max_analog_value default config & add check

### DIFF
--- a/driver/opengloves/resources/settings/default.vrsettings
+++ b/driver/opengloves/resources/settings/default.vrsettings
@@ -38,7 +38,7 @@
   "communication_namedpipe": {
     "enable": false
   },
-  "encoding": {
+  "encoding_alpha": {
     "max_analog_value": 4095
   }
 }

--- a/driver/src/device/configuration/device_configuration.cpp
+++ b/driver/src/device/configuration/device_configuration.cpp
@@ -2,6 +2,9 @@
 
 #include "util/driver_math.h"
 
+#include "opengloves_interface.h"
+#include "services/webserver_logging.h"
+
 const char* k_driver_settings_section = "driver_opengloves";
 
 const char* k_device_lucidgloves_section = "device_lucidgloves";
@@ -13,6 +16,8 @@ const char* k_serial_communication_settings_section = "communication_serial";
 const char* k_btserial_communication_settings_section = "communication_btserial";
 const char* k_namedpipe_communication_settings_section = "communication_namedpipe";
 const char* k_alpha_encoding_settings_section = "encoding_alpha";
+
+static og::Logger& logger = og::Logger::GetInstance();
 
 nlohmann::ordered_map<std::string, std::variant<bool>> GetDriverConfigurationMap() {
   nlohmann::ordered_map<std::string, std::variant<bool>> result{};
@@ -63,6 +68,9 @@ nlohmann::ordered_map<std::string, std::variant<int>> GetAlphaEncodingConfigurat
   nlohmann::ordered_map<std::string, std::variant<int>> result{};
 
   result["max_analog_value"] = vr::VRSettings()->GetInt32(k_alpha_encoding_settings_section, "max_analog_value");
+
+  if (std::get<int>(result["max_analog_value"]) == 0)
+      logger.Log(og::kLoggerLevel_Error, "max_analog_value is set to zero. This will cause errors, and your glove probably won't work.");
 
   return result;
 }

--- a/driver/src/device/configuration/device_configuration.cpp
+++ b/driver/src/device/configuration/device_configuration.cpp
@@ -2,8 +2,7 @@
 
 #include "util/driver_math.h"
 
-#include "opengloves_interface.h"
-#include "services/webserver_logging.h"
+#include "util/driver_log.h"
 
 const char* k_driver_settings_section = "driver_opengloves";
 
@@ -16,8 +15,6 @@ const char* k_serial_communication_settings_section = "communication_serial";
 const char* k_btserial_communication_settings_section = "communication_btserial";
 const char* k_namedpipe_communication_settings_section = "communication_namedpipe";
 const char* k_alpha_encoding_settings_section = "encoding_alpha";
-
-static og::Logger& logger = og::Logger::GetInstance();
 
 nlohmann::ordered_map<std::string, std::variant<bool>> GetDriverConfigurationMap() {
   nlohmann::ordered_map<std::string, std::variant<bool>> result{};
@@ -70,7 +67,7 @@ nlohmann::ordered_map<std::string, std::variant<int>> GetAlphaEncodingConfigurat
   result["max_analog_value"] = vr::VRSettings()->GetInt32(k_alpha_encoding_settings_section, "max_analog_value");
 
   if (std::get<int>(result["max_analog_value"]) == 0)
-      logger.Log(og::kLoggerLevel_Error, "max_analog_value is set to zero. This will cause errors, and your glove probably won't work.");
+    DriverLog("max_analog_value is set to zero. This will cause errors, and your glove probably won't work.");
 
   return result;
 }


### PR DESCRIPTION
Changes the "encoding" field in the default.vrsettings to "encoding_alpha" and adds a check to device_configuration.cpp to catch it if it's zero.

If this value is set to zero, a division by zero happens in alpha encoding service that results in a NaN value, which cascades into problems setting bone position in knuclke_device_driver.cpp.

This bug might manifest itself in a Unity game by an error message that reads:

`transform.localPosition assign attempt for ... is not valid. Input localPosition is { NaN, NaN, NaN }`